### PR TITLE
Add FastAPI NotebookLM automation service and Kindle connector stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# NotebookLM MVP
+# NotebookLM MVP Workflow Service
+
+This repository contains a FastAPI-based workflow service that automates Google
+NotebookLM using Playwright. It also ships with helper scripts to capture login
+cookies once, reuse them for automation, and a stub Kindle connector ready for
+future expansion.
+
+## Project Layout
+
+```
+.
+├── app/
+│   ├── config.py              # Configuration loader for selectors and timeouts
+│   ├── main.py                # FastAPI application
+│   └── notebooklm_client.py   # Async Playwright client
+├── config.json                # Editable selectors for the NotebookLM UI
+├── kindle_connector.py        # EPUB/MOBI extraction stub
+├── scripts/
+│   ├── run_workflow.py        # Example automation using saved cookies
+│   └── save_cookies.py        # Manual login helper
+└── README.md
+```
+
+## Prerequisites
+
+- Python 3.10+
+- [Playwright](https://playwright.dev/python/) with Chromium browser binaries
+  installed (`playwright install chromium`)
+- FastAPI (install via `pip install -r requirements.txt` once created)
+- A valid Google account with access to NotebookLM
+
+## Capturing Login Cookies
+
+1. Install dependencies and Playwright browsers.
+2. Run the helper script and log in manually in the spawned browser window:
+
+   ```bash
+   python scripts/save_cookies.py
+   ```
+
+   The script saves serialized cookies to `cookies.json`. Adjust the path with
+   `--output` if needed.
+
+## Running Automation From the CLI
+
+Reuse the saved cookies to upload a document and optionally run a query:
+
+```bash
+python scripts/run_workflow.py --upload /path/to/document.pdf --query "Summarize chapter 1" --headless
+```
+
+The script prints structured JSON describing the automation results.
+
+## FastAPI Service
+
+Start the service with Uvicorn:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Available endpoints:
+
+- `POST /upload` – accepts a multipart file upload and pushes the document to
+  NotebookLM. Returns the processing status as JSON.
+- `POST /query` – accepts `{ "query": "..." }` and responds with the AI answer
+  plus extracted citations.
+
+Configuration is read from `config.json` by default. Override locations and
+runtime behaviour using environment variables:
+
+- `NOTEBOOKLM_CONFIG_PATH` – custom path to a configuration file.
+- `NOTEBOOKLM_COOKIES_PATH` – path to the saved cookies file.
+- `NOTEBOOKLM_HEADLESS` – set to `False` to run the browser with a UI.
+
+## Kindle Connector Stub
+
+`kindle_connector.py` implements `extract_kindle_book(file_path)` which converts
+an EPUB or MOBI file into structured JSON:
+
+```python
+from kindle_connector import extract_kindle_book
+
+book = extract_kindle_book("/path/to/book.epub")
+print(book["title"], book["chapters"][0]["text"][:200])
+```
+
+The EPUB extraction uses only the Python standard library. MOBI support is
+intentionally naive and should be replaced with a parser such as the
+[Kindle API project](https://github.com/Xetera/kindle-api) for production use.
+
+## Next Steps
+
+- Harden the selectors in `config.json` to match the live NotebookLM DOM.
+- Persist per-document context (Notebook IDs) to enable targeted queries.
+- Replace the MOBI stub with DRM-aware extraction tied to a single device key.

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,53 @@
+"""Utilities for loading configuration values used by the NotebookLM workflow service."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+DEFAULT_CONFIG_PATH = pathlib.Path(__file__).resolve().parent.parent / "config.json"
+
+
+@dataclass
+class SelectorConfig:
+    """Configuration values for interacting with NotebookLM via Playwright."""
+
+    base_url: str
+    upload: Dict[str, str]
+    query: Dict[str, str]
+    timeouts: Dict[str, int]
+
+
+def load_config(path: pathlib.Path | str | None = None) -> SelectorConfig:
+    """Load configuration for the automation layer.
+
+    Parameters
+    ----------
+    path:
+        Optional path to a JSON configuration file. If not provided the default
+        ``config.json`` at the repository root is used.
+    """
+
+    config_path = pathlib.Path(path or DEFAULT_CONFIG_PATH)
+    if not config_path.exists():
+        raise FileNotFoundError(f"Configuration file not found: {config_path}")
+
+    with config_path.open("r", encoding="utf-8") as fp:
+        data: Dict[str, Any] = json.load(fp)
+
+    notebooklm_cfg = data.get("notebooklm")
+    if not notebooklm_cfg:
+        raise KeyError("Missing 'notebooklm' section in configuration file")
+
+    return SelectorConfig(
+        base_url=notebooklm_cfg["base_url"],
+        upload=notebooklm_cfg.get("upload", {}),
+        query=notebooklm_cfg.get("query", {}),
+        timeouts=notebooklm_cfg.get("timeouts", {}),
+    )
+
+
+__all__ = ["SelectorConfig", "load_config"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,110 @@
+"""FastAPI service exposing the NotebookLM automation workflow."""
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+import tempfile
+from typing import Any, Awaitable, Dict
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+from pydantic import BaseModel, BaseSettings
+
+from .config import SelectorConfig, load_config
+from .notebooklm_client import NotebookLMClient, NotebookLMError
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Settings(BaseSettings):
+    """Application settings configurable via environment variables."""
+
+    config_path: pathlib.Path | None = None
+    cookies_path: pathlib.Path = pathlib.Path("cookies.json")
+    headless: bool = True
+
+    class Config:
+        env_prefix = "NOTEBOOKLM_"
+        case_sensitive = False
+
+
+settings = Settings()
+app = FastAPI(title="NotebookLM Workflow Service", version="0.1.0")
+
+
+@app.on_event("startup")
+async def configure_logging() -> None:
+    logging.basicConfig(level=logging.INFO)
+
+
+def _load_selector_config() -> SelectorConfig:
+    config_path = settings.config_path
+    return load_config(config_path) if config_path else load_config()
+
+
+class QueryPayload(BaseModel):
+    query: str
+
+
+async def _run_notebooklm_action(
+    action: str,
+    coroutine: Awaitable[Dict[str, Any]],
+) -> Dict[str, Any]:
+    try:
+        return await coroutine
+    except NotebookLMError as exc:
+        LOGGER.exception("NotebookLM workflow failed during %s", action)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@app.post("/upload")
+async def upload_document(file: UploadFile = File(...)) -> Dict[str, Any]:
+    """Upload a document to NotebookLM using the automation client."""
+
+    selector_config = _load_selector_config()
+    cookies_path = settings.cookies_path
+
+    suffix = pathlib.Path(file.filename or "").suffix
+    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+        contents = await file.read()
+        tmp.write(contents)
+        tmp_path = pathlib.Path(tmp.name)
+
+    try:
+        async with NotebookLMClient(selector_config, cookies_path, headless=settings.headless) as client:
+            result = await _run_notebooklm_action(
+                "upload",
+                client.upload_document(tmp_path),
+            )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            LOGGER.warning("Unable to remove temporary file %s", tmp_path)
+
+    return {"status": "success", "details": result}
+
+
+@app.post("/query")
+async def query_notebooklm(payload: QueryPayload) -> Dict[str, Any]:
+    """Submit a query to NotebookLM and return the AI response."""
+
+    selector_config = _load_selector_config()
+    cookies_path = settings.cookies_path
+
+    try:
+        async with NotebookLMClient(selector_config, cookies_path, headless=settings.headless) as client:
+            response = await _run_notebooklm_action(
+                "query",
+                client.query(payload.query),
+            )
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return response
+
+
+__all__ = ["app"]

--- a/app/notebooklm_client.py
+++ b/app/notebooklm_client.py
@@ -1,0 +1,212 @@
+"""Async client for automating Google NotebookLM via Playwright."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from contextlib import asynccontextmanager
+from typing import Any, Dict, List, Optional
+
+from playwright.async_api import Browser, BrowserContext, Error, Page, async_playwright
+
+from .config import SelectorConfig
+
+LOGGER = logging.getLogger(__name__)
+
+
+class NotebookLMError(RuntimeError):
+    """Raised when the automation workflow cannot complete successfully."""
+
+
+class NotebookLMClient:
+    """High-level automation wrapper around the NotebookLM web UI."""
+
+    def __init__(
+        self,
+        config: SelectorConfig,
+        cookies_path: str | pathlib.Path,
+        headless: bool = True,
+        navigation_timeout: Optional[int] = None,
+    ) -> None:
+        self._config = config
+        self._cookies_path = pathlib.Path(cookies_path)
+        self._headless = headless
+        self._navigation_timeout = navigation_timeout or config.timeouts.get("page_load", 30000)
+        self._playwright_cm = async_playwright()
+        self._browser: Optional[Browser] = None
+        self._context: Optional[BrowserContext] = None
+        self._page: Optional[Page] = None
+
+    async def __aenter__(self) -> "NotebookLMClient":
+        self._playwright = await self._playwright_cm.__aenter__()
+        self._browser = await self._playwright.chromium.launch(headless=self._headless)
+        self._context = await self._browser.new_context()
+        await self._load_cookies()
+        self._page = await self._context.new_page()
+        self._page.set_default_timeout(self._navigation_timeout)
+        await self._page.goto(self._config.base_url, wait_until="networkidle")
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        await self._cleanup()
+
+    async def _cleanup(self) -> None:
+        try:
+            if self._context:
+                await self._context.close()
+        finally:
+            if self._browser:
+                await self._browser.close()
+            await self._playwright_cm.__aexit__(None, None, None)
+
+    async def _load_cookies(self) -> None:
+        if not self._cookies_path.exists():
+            raise FileNotFoundError(
+                f"Cookie file not found at {self._cookies_path}. Run the save_cookies script first."
+            )
+
+        with self._cookies_path.open("r", encoding="utf-8") as fh:
+            cookies = json.load(fh)
+
+        if not isinstance(cookies, list):
+            raise NotebookLMError("Cookies file must contain a list of serialized cookies")
+
+        if not self._context:
+            raise NotebookLMError("Browser context is not initialized")
+
+        await self._context.add_cookies(cookies)
+
+    # ------------------------------------------------------------------
+    # Upload flow
+    # ------------------------------------------------------------------
+    async def upload_document(self, file_path: str | pathlib.Path) -> Dict[str, Any]:
+        """Upload a document and wait until NotebookLM finishes processing it."""
+
+        if not self._page:
+            raise NotebookLMError("Client is not initialized. Use as an async context manager.")
+
+        file_path = str(pathlib.Path(file_path).resolve())
+        upload_cfg = self._config.upload
+        add_button_selector = upload_cfg.get("add_source_button")
+        file_input_selector = upload_cfg.get("file_input")
+
+        if not add_button_selector or not file_input_selector:
+            raise NotebookLMError("Upload selectors are missing from the configuration file.")
+
+        LOGGER.debug("Navigating to NotebookLM base URL: %s", self._config.base_url)
+        await self._page.goto(self._config.base_url, wait_until="networkidle")
+
+        LOGGER.debug("Clicking the add source button (%s)", add_button_selector)
+        await self._page.click(add_button_selector)
+
+        file_input = self._page.locator(file_input_selector)
+        if not await file_input.is_visible():
+            LOGGER.debug("File input not visible, forcing state by setting input")
+
+        LOGGER.info("Uploading file %s", file_path)
+        await file_input.set_input_files(file_path)
+
+        processed_selector = upload_cfg.get("processed_marker")
+        processing_indicator = upload_cfg.get("processing_indicator")
+        processing_timeout = self._config.timeouts.get("processing", 180000)
+
+        if processed_selector:
+            LOGGER.debug("Waiting for processed marker (%s)", processed_selector)
+            await self._page.wait_for_selector(
+                processed_selector,
+                state="visible",
+                timeout=processing_timeout,
+            )
+        elif processing_indicator:
+            LOGGER.debug("Waiting for processing indicator (%s) to disappear", processing_indicator)
+            await self._page.wait_for_selector(
+                processing_indicator,
+                state="hidden",
+                timeout=processing_timeout,
+            )
+        else:
+            LOGGER.warning(
+                "No processing selector configured; applying fixed delay as a fallback."
+            )
+            await asyncio.sleep(processing_timeout / 1000)
+
+        return {"file_path": file_path, "status": "processed"}
+
+    # ------------------------------------------------------------------
+    # Query flow
+    # ------------------------------------------------------------------
+    async def query(self, query: str) -> Dict[str, Any]:
+        """Submit a query and return the structured response."""
+
+        if not self._page:
+            raise NotebookLMError("Client is not initialized. Use as an async context manager.")
+
+        query_cfg = self._config.query
+        prompt_selector = query_cfg.get("prompt_input")
+        submit_selector = query_cfg.get("submit_button")
+        response_selector = query_cfg.get("response_container")
+
+        if not prompt_selector or not response_selector:
+            raise NotebookLMError("Query selectors are missing from the configuration file.")
+
+        LOGGER.debug("Focusing prompt input (%s)", prompt_selector)
+        prompt_input = self._page.locator(prompt_selector)
+        await prompt_input.click()
+        await prompt_input.fill(query)
+
+        if submit_selector:
+            LOGGER.debug("Submitting prompt via button (%s)", submit_selector)
+            await self._page.click(submit_selector)
+        else:
+            LOGGER.debug("Submitting prompt via Enter key")
+            await prompt_input.press("Enter")
+
+        response_timeout = self._config.timeouts.get("response", 120000)
+        LOGGER.debug("Waiting for response container (%s)", response_selector)
+        await self._page.wait_for_selector(response_selector, state="visible", timeout=response_timeout)
+
+        response_locator = self._page.locator(response_selector).first
+        answer_text = (await response_locator.inner_text()).strip()
+
+        citations: List[str] = []
+        citation_selector = query_cfg.get("citation_selector")
+        if citation_selector:
+            LOGGER.debug("Collecting citations using selector %s", citation_selector)
+            try:
+                citation_locators = self._page.locator(citation_selector)
+                count = await citation_locators.count()
+                for idx in range(count):
+                    text = await citation_locators.nth(idx).inner_text()
+                    text = text.strip()
+                    if text:
+                        citations.append(text)
+            except Error as exc:  # pragma: no cover - depends on runtime DOM structure
+                LOGGER.warning("Failed to extract citations: %s", exc)
+
+        return {"query": query, "answer": answer_text, "citations": citations}
+
+
+@asynccontextmanager
+async def notebooklm_client(
+    config: SelectorConfig,
+    cookies_path: str | pathlib.Path,
+    headless: bool = True,
+    navigation_timeout: Optional[int] = None,
+):
+    """Context manager yielding a :class:`NotebookLMClient`."""
+
+    client = NotebookLMClient(config, cookies_path, headless=headless, navigation_timeout=navigation_timeout)
+    try:
+        await client.__aenter__()
+        yield client
+    finally:
+        await client.__aexit__(None, None, None)
+
+
+__all__ = [
+    "NotebookLMClient",
+    "NotebookLMError",
+    "notebooklm_client",
+]

--- a/config.json
+++ b/config.json
@@ -1,0 +1,22 @@
+{
+  "notebooklm": {
+    "base_url": "https://notebooklm.google.com/",
+    "upload": {
+      "add_source_button": "[data-testid='add-source']",
+      "file_input": "input[type=\"file\"]",
+      "processing_indicator": "[data-testid='source-processing']",
+      "processed_marker": "[data-testid='source-ready']"
+    },
+    "query": {
+      "prompt_input": "textarea[aria-label='Ask a question']",
+      "submit_button": "button[data-testid='send-prompt']",
+      "response_container": "[data-testid='response-card']",
+      "citation_selector": "[data-testid='citation-chip']"
+    },
+    "timeouts": {
+      "page_load": 30000,
+      "processing": 180000,
+      "response": 120000
+    }
+  }
+}

--- a/kindle_connector.py
+++ b/kindle_connector.py
@@ -1,0 +1,135 @@
+"""Stub implementation for extracting content from Kindle-compatible files.
+
+This module is intentionally lightweight for the MVP. It focuses on EPUB
+parsing using the standard library and provides a very naive MOBI fallback.
+It is designed so that future work can plug in proper DRM-aware extraction as
+illustrated in https://github.com/Xetera/kindle-api.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Dict, List
+from zipfile import ZipFile
+
+
+@dataclass
+class Chapter:
+    chapter: int
+    text: str
+
+
+@dataclass
+class KindleBook:
+    title: str
+    author: str
+    chapters: List[Chapter]
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "title": self.title,
+            "author": self.author,
+            "chapters": [chapter.__dict__ for chapter in self.chapters],
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, ensure_ascii=False)
+
+
+class _HTMLTextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._chunks: List[str] = []
+
+    def handle_data(self, data: str) -> None:
+        text = data.strip()
+        if text:
+            self._chunks.append(text)
+
+    def get_text(self) -> str:
+        return " ".join(self._chunks)
+
+
+def _strip_html(content: bytes) -> str:
+    parser = _HTMLTextExtractor()
+    parser.feed(content.decode("utf-8", errors="ignore"))
+    return parser.get_text()
+
+
+def _extract_epub(file_path: pathlib.Path) -> KindleBook:
+    title = file_path.stem
+    author = "Unknown"
+    chapters: List[Chapter] = []
+
+    with ZipFile(file_path) as archive:
+        opf_path = next((name for name in archive.namelist() if name.endswith(".opf")), None)
+        if opf_path:
+            import xml.etree.ElementTree as ET
+
+            root = ET.fromstring(archive.read(opf_path))
+            ns = {"dc": "http://purl.org/dc/elements/1.1/"}
+            title_elem = root.find(".//dc:title", ns)
+            creator_elem = root.find(".//dc:creator", ns)
+            if title_elem is not None and title_elem.text:
+                title = title_elem.text.strip()
+            if creator_elem is not None and creator_elem.text:
+                author = creator_elem.text.strip()
+
+        html_files = [name for name in archive.namelist() if name.endswith((".xhtml", ".html", ".htm"))]
+        for idx, name in enumerate(sorted(html_files), start=1):
+            text = _strip_html(archive.read(name))
+            if text:
+                chapters.append(Chapter(chapter=idx, text=text))
+
+    if not chapters:
+        chapters.append(Chapter(chapter=1, text=""))
+
+    return KindleBook(title=title, author=author, chapters=chapters)
+
+
+def _extract_mobi(file_path: pathlib.Path) -> KindleBook:
+    # MOBI is a proprietary format; for the MVP we perform a very naive extraction
+    # by attempting to decode the binary file into UTF-8 and splitting on common
+    # chapter markers. This should be replaced with a proper parser such as the
+    # one provided by https://github.com/Xetera/kindle-api.
+    data = file_path.read_bytes().decode("utf-8", errors="ignore")
+    title = file_path.stem
+    author = "Unknown"
+
+    chunks = re.split(r"\n\s*chapter\s+\d+\s*\n", data, flags=re.IGNORECASE)
+    chapters: List[Chapter] = []
+
+    for idx, chunk in enumerate(chunks, start=1):
+        text = chunk.strip()
+        if text:
+            chapters.append(Chapter(chapter=idx, text=text))
+
+    if not chapters:
+        chapters.append(Chapter(chapter=1, text=data.strip()))
+
+    return KindleBook(title=title, author=author, chapters=chapters)
+
+
+def extract_kindle_book(file_path: str | pathlib.Path) -> Dict[str, object]:
+    """Extract the contents of an EPUB or MOBI book into structured JSON."""
+
+    path = pathlib.Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    suffix = path.suffix.lower()
+    if suffix == ".epub":
+        book = _extract_epub(path)
+    elif suffix == ".mobi":
+        book = _extract_mobi(path)
+    else:
+        raise ValueError("Unsupported file format. Expected .epub or .mobi")
+
+    return book.to_dict()
+
+
+__all__ = ["extract_kindle_book", "KindleBook", "Chapter"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+playwright

--- a/scripts/run_workflow.py
+++ b/scripts/run_workflow.py
@@ -1,0 +1,77 @@
+"""Script demonstrating how to automate NotebookLM using saved cookies."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import pathlib
+from typing import Any, Dict, Optional
+
+from app.config import load_config
+from app.notebooklm_client import NotebookLMClient
+
+
+async def run_workflow(
+    cookies_path: pathlib.Path,
+    config_path: Optional[str],
+    upload_path: Optional[pathlib.Path],
+    query_text: Optional[str],
+    headless: bool,
+) -> Dict[str, Any]:
+    config = load_config(config_path)
+    results: Dict[str, Any] = {}
+
+    async with NotebookLMClient(config, cookies_path, headless=headless) as client:
+        if upload_path:
+            results["upload"] = await client.upload_document(upload_path)
+        if query_text:
+            results["query"] = await client.query(query_text)
+
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run NotebookLM automation using stored cookies")
+    parser.add_argument(
+        "--cookies",
+        type=pathlib.Path,
+        default=pathlib.Path("cookies.json"),
+        help="Path to cookies.json captured via scripts/save_cookies.py",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Optional path to config.json",
+    )
+    parser.add_argument(
+        "--upload",
+        type=pathlib.Path,
+        default=None,
+        help="Optional path to a document that should be uploaded",
+    )
+    parser.add_argument(
+        "--query",
+        type=str,
+        default=None,
+        help="Optional query to submit after the upload step",
+    )
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="Run Playwright in headless mode (default: headed)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    results = asyncio.run(
+        run_workflow(args.cookies, args.config, args.upload, args.query, args.headless)
+    )
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/save_cookies.py
+++ b/scripts/save_cookies.py
@@ -1,0 +1,69 @@
+"""Manual login helper script for capturing NotebookLM authentication cookies."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import pathlib
+from typing import Optional
+
+from playwright.async_api import async_playwright
+
+from app.config import load_config
+
+
+async def capture_cookies(output_path: pathlib.Path, config_path: Optional[str] = None, slow_mo: int = 0) -> None:
+    config = load_config(config_path)
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=False, slow_mo=slow_mo)
+        context = await browser.new_context()
+        page = await context.new_page()
+        await page.goto(config.base_url)
+
+        print(
+            "\nPlease complete the NotebookLM login flow in the opened browser window."
+            "\nWhen the application has fully loaded, return to this terminal and press ENTER."
+        )
+        input("Press ENTER once you are logged in...")
+
+        cookies = await context.cookies()
+
+        output_path.write_text(json.dumps(cookies, indent=2), encoding="utf-8")
+        print(f"Saved {len(cookies)} cookies to {output_path}")
+
+        await context.close()
+        await browser.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Save NotebookLM auth cookies to disk")
+    parser.add_argument(
+        "--output",
+        type=pathlib.Path,
+        default=pathlib.Path("cookies.json"),
+        help="Destination file for serialized cookies (default: cookies.json)",
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        help="Optional path to config.json with selectors and base URL.",
+    )
+    parser.add_argument(
+        "--slow-mo",
+        type=int,
+        default=0,
+        help="Optional slow motion delay in milliseconds for Playwright (useful for debugging).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(capture_cookies(args.output, args.config, args.slow_mo))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a Playwright-based NotebookLM automation client with configurable selectors and expose it via FastAPI endpoints
- add scripts for capturing login cookies and running uploads/queries using saved sessions
- provide a Kindle connector stub for extracting EPUB/MOBI content and update documentation with usage details

## Testing
- python -m compileall app scripts kindle_connector.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fdbad6f083268f46c272b57b43ac