### PR TITLE
Adjust NotebookLM navigation waits to default behavior

### DIFF
--- a/app/notebooklm_client.py
+++ b/app/notebooklm_client.py
@@ -46,7 +46,7 @@ class NotebookLMClient:
         await self._load_cookies()
         self._page = await self._context.new_page()
         self._page.set_default_timeout(self._navigation_timeout)
-        await self._page.goto(self._config.base_url, wait_until="networkidle")
+        await self._page.goto(self._config.base_url)
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
@@ -96,7 +96,7 @@ class NotebookLMClient:
             raise NotebookLMError("Upload selectors are missing from the configuration file.")
 
         LOGGER.debug("Navigating to NotebookLM base URL: %s", self._config.base_url)
-        await self._page.goto(self._config.base_url, wait_until="networkidle")
+        await self._page.goto(self._config.base_url)
 
         LOGGER.debug("Clicking the add source button (%s)", add_button_selector)
         await self._page.click(add_button_selector)


### PR DESCRIPTION
## Summary
- remove the explicit `networkidle` waits from NotebookLM navigation so Playwright uses its default load handling

## Testing
- python -m scripts.run_workflow --headless *(fails: Playwright browser binaries not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da04afa6b08326ac6cf909c634bded